### PR TITLE
Fix sale page overflow issue

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,6 +175,7 @@
     font-family: 'Geoform', 'Roboto Custom', 'Etude Noire', 'Aviano', 'Squad', system-ui, sans-serif;
     font-feature-settings: 'kern' 1, 'liga' 1;
     zoom: 0.9;
+    overflow-x: hidden;
   }
 
   .container {
@@ -204,8 +205,8 @@
     content: '';
     position: absolute;
     top: -50px;
-    left: -100px;
-    right: -100px;
+    left: 0;
+    width: 100%;
     bottom: -100px;
     background: #0f172a; /* slate-900 */
     z-index: -1;


### PR DESCRIPTION
The /sale page had an issue where it was possible to zoom out and see a white space on the right side of the page. This was caused by the footer's pseudo-element being wider than the viewport.

This commit fixes the issue by:
- Adding `overflow-x: hidden` to the body to prevent horizontal scrolling.
- Changing the footer's pseudo-element to use `width: 100%` instead of negative left/right values.