### PR TITLE
fix: Использовать относительный путь для API-запросов

### DIFF
--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -11,7 +11,11 @@ export class ApiClient {
   private baseUrl: string
 
   constructor() {
-    this.baseUrl = process.env.NEXT_PUBLIC_API_HOST || 'https://api.belautocenter.by'
+    // Используем относительный путь по умолчанию.
+    // Это позволяет коду работать на любом домене (Vercel, localhost, production),
+    // так как запросы будут отправляться на тот же хост, с которого загружена страница.
+    // Переменная NEXT_PUBLIC_API_HOST остается для гибкости, если понадобится указать другой хост.
+    this.baseUrl = process.env.NEXT_PUBLIC_API_HOST || ''
   }
 
   async fetch<T>(


### PR DESCRIPTION
В `ApiClient` был жестко прописан производственный URL (`https://api.belautocenter.by`) в качестве запасного варианта для базового URL API.

Это приводило к сбоям при загрузке данных на непроизводственных развертываниях (например, в превью на Vercel) из-за ошибок CORS.

Данное изменение заменяет жестко прописанный URL на пустую строку, что заставляет все API-вызовы по умолчанию использовать относительные пути. Это гарантирует, что фронтенд будет корректно взаимодействовать с бэкендом на любом домене, на котором он развернут.