### PR TITLE
Unified Meta-style Submission Modal for Forms

### DIFF
--- a/app/catalog/[id]/car-details-client.tsx
+++ b/app/catalog/[id]/car-details-client.tsx
@@ -23,6 +23,7 @@ import { Slider } from "@/components/ui/slider"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import { useSettings } from "@/hooks/use-settings"
 import { FinancialAssistantDrawer } from "@/components/FinancialAssistantDrawer"
 import {
@@ -248,6 +249,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
 
   // Notification hook
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   // Settings hook
   const { settings } = useSettings()
@@ -590,10 +592,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
   const handleBookingSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (bookingButtonState.state === 'loading') return;
-
-    await bookingButtonState.execute(async () => {
-      // Сохраняем данные через Firebase клиентский SDK (независимо от результата)
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...bookingForm,
@@ -606,8 +605,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
       } catch (error) {
       }
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch('/api/send-telegram', {
+      const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -623,20 +621,17 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
           type: 'car_booking'
         })
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
-      setIsBookingOpen(false)
       setBookingForm({ name: "", phone: "+375", message: "" })
       showSuccess("Заявка на бронирование успешно отправлена! Мы свяжемся с вами в ближайшее время.")
-    })
+    }, () => setIsBookingOpen(false))
   }
 
   const handleCallbackSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (callbackButtonState.state === 'loading') return;
-
-    await callbackButtonState.execute(async () => {
-      // Сохраняем данные через Firebase клиентский SDK (независимо от результата)
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...callbackForm,
@@ -649,8 +644,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
       } catch (error) {
       }
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch('/api/send-telegram', {
+      const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -665,20 +659,17 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
           type: 'callback'
         })
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
-      setIsCallbackOpen(false)
       setCallbackForm({ name: "", phone: "+375" })
       showSuccess("Заявка на обратный звонок успешно отправлена! Мы свяжемся с вами в ближайшее время.")
-    })
+    }, () => setIsCallbackOpen(false))
   }
 
   const handleCreditSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (creditButtonState.state === 'loading') return;
-
-    await creditButtonState.execute(async () => {
-      // Сохраняем данные через Firebase клиентский SDK (независимо от результата)
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...creditForm,
@@ -698,8 +689,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
       } catch (error) {
       }
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch('/api/send-telegram', {
+      const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -724,11 +714,11 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
           type: financeType === 'credit' ? 'credit_request' : 'leasing_request'
         })
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
-      setIsCreditFormOpen(false)
       setCreditForm({ name: "", phone: "+375", message: "" })
       showSuccess(`Заявка на ${financeType === 'credit' ? 'кредит' : 'лизинг'} успешно отправлена! Мы рассмотрим ее и свяжемся с вами в ближайшее время.`)
-    })
+    }, () => setIsCreditFormOpen(false))
   }
 
 
@@ -1760,17 +1750,14 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
   onOpenChange={setIsBookingOpen}
   title="Записаться на просмотр"
   footer={
-    <StatusButton
+    <Button
       type="submit"
       form="booking-form"
       className="w-full"
-      state={bookingButtonState.state}
-      loadingText="Отправляем..."
-      successText="Заявка отправлена!"
-      errorText="Ошибка"
+      disabled={!isPhoneValid(bookingForm.phone) || !bookingForm.name}
     >
       Записаться на просмотр
-    </StatusButton>
+    </Button>
   }
 >
   <form id="booking-form" onSubmit={handleBookingSubmit} className="space-y-4">
@@ -1816,17 +1803,14 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
   onOpenChange={setIsCallbackOpen}
   title="Заказать обратный звонок"
   footer={
-    <StatusButton
+    <Button
       type="submit"
       form="callback-form"
       className="w-full"
-      state={callbackButtonState.state}
-      loadingText="Отправляем..."
-      successText="Заявка отправлена!"
-      errorText="Ошибка"
+      disabled={!isPhoneValid(callbackForm.phone) || !callbackForm.name}
     >
       Жду звонка
-    </StatusButton>
+    </Button>
   }
 >
   <form id="callback-form" onSubmit={handleCallbackSubmit} className="space-y-4">
@@ -1960,16 +1944,13 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
                 </div>
               )}
 
-              <StatusButton
+              <Button
                 type="submit"
                 className="w-full h-9 sm:h-10 text-sm"
-                state={creditButtonState.state}
-                loadingText="Отправляем..."
-                successText="Заявка отправлена!"
-                errorText="Ошибка"
+                disabled={!isPhoneValid(creditForm.phone) || !creditForm.name}
               >
                 Отправить заявку на {financeType === 'credit' ? 'кредит' : 'лизинг'}
-              </StatusButton>
+              </Button>
             </form>
           </DialogContent>
         </Dialog>

--- a/app/contacts/contacts-client.tsx
+++ b/app/contacts/contacts-client.tsx
@@ -16,6 +16,7 @@ import {
   Instagram
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { StatusButton } from '@/components/ui/status-button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -23,6 +24,7 @@ import { Textarea } from '@/components/ui/textarea'
 import YandexMap from '@/components/yandex-map'
 import { useButtonState } from '@/hooks/use-button-state'
 import { useNotification } from '@/components/providers/notification-provider'
+import { useSubmission } from '@/components/providers/submission-provider'
 import { formatPhoneNumber, isPhoneValid } from "@/lib/validation"
 
 interface ContactsData {
@@ -71,6 +73,7 @@ export default function ContactsClient({ contactsData }: ContactsClientProps) {
   })
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -79,7 +82,7 @@ export default function ContactsClient({ contactsData }: ContactsClientProps) {
       return
     }
 
-    await submitButtonState.execute(async () => {
+    await submitForm(async () => {
       // Отправка через API
       const response = await fetch('/api/send-telegram', {
         method: 'POST',
@@ -101,7 +104,7 @@ export default function ContactsClient({ contactsData }: ContactsClientProps) {
       // Очистка формы после успешной отправки
       setContactForm({ name: '', phone: '', message: '' })
       showSuccess("Ваше сообщение успешно отправлено! Мы ответим вам в ближайшее время.")
-    })
+    }) // Здесь нет окна для закрытия
   }
 
   return (
@@ -379,18 +382,15 @@ export default function ContactsClient({ contactsData }: ContactsClientProps) {
                 </div>
 
                 <div className="pt-2">
-                  <StatusButton
+                  <Button
                     type="submit"
                     size="lg"
-                    state={submitButtonState.state}
+                    disabled={!isPhoneValid(contactForm.phone) || !contactForm.name}
                     className="w-full bg-gradient-to-br from-slate-800 to-slate-900 dark:from-slate-700 dark:to-slate-800 hover:from-slate-900 hover:to-black dark:hover:from-slate-600 dark:hover:to-slate-700 text-white font-semibold shadow-lg hover:shadow-xl transition-all duration-300 text-sm"
-                    loadingText="Отправляем..."
-                    successText="Отправлено!"
-                    errorText="Ошибка отправки"
                   >
                     <Send className="h-3 w-3 md:h-4 md:w-4 mr-2" />
                     Отправить сообщение
-                  </StatusButton>
+                  </Button>
                 </div>
               </form>
             </CardContent>

--- a/app/credit/page.tsx
+++ b/app/credit/page.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label"
 import { Slider } from "@/components/ui/slider"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ChevronRight, Check, DollarSign, Zap, Shield, FileText, Award, Phone, Car, Star, CheckCircle, CreditCard, ChevronDown, ChevronUp, Calculator } from "lucide-react"
@@ -48,6 +49,7 @@ export default function CreditPage() {
   const usdBynRate = useUsdBynRate()
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   const [calculator, setCalculator] = useState({
     carPrice: [50000],
@@ -246,11 +248,11 @@ export default function CreditPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!isFormValid() || submitButtonState.state === 'loading') {
+    if (!isFormValid()) {
       return
     }
 
-    await submitButtonState.execute(async () => {
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...creditForm,
@@ -261,8 +263,7 @@ export default function CreditPage() {
       } catch (error) {
       }
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -272,6 +273,7 @@ export default function CreditPage() {
           type: "credit_request",
         }),
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
       setCreditForm({
         name: "",
@@ -283,10 +285,8 @@ export default function CreditPage() {
         bank: "",
         message: "",
       })
-      showSuccess(
-        "Заявка на кредит успешно отправлена! Мы рассмотрим ее и свяжемся с вами в ближайшее время."
-      )
-    })
+      showSuccess("Заявка на кредит успешно отправлена! Мы рассмотрим ее и свяжемся с вами в ближайшее время.")
+    }) // Здесь нет окна для закрытия
   }
 
   const monthlyPayment = calculateMonthlyPayment()
@@ -749,17 +749,13 @@ export default function CreditPage() {
                     </div>
                   </div>
 
-                  <StatusButton
+                  <Button
                     type="submit"
                     className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white rounded-xl py-3 mt-3 font-semibold text-sm shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                    state={submitButtonState.state}
-                    loadingText="Отправляем..."
-                    successText="Отправлено!"
-                    errorText="Ошибка"
                     disabled={!isFormValid()}
                   >
                     Отправить заявку на кредит
-                  </StatusButton>
+                  </Button>
 
                   <p className="text-xs text-slate-600 dark:text-slate-400 leading-tight text-center">
                     Нажимая кнопку "Отправить заявку на кредит", вы соглашаетесь с{" "}

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -14,6 +14,7 @@ import DynamicSelection from "@/components/dynamic-selection"
 import DynamicSelectionSkeleton from "@/components/dynamic-selection-skeleton"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import SaleModal from "@/app/sale/sale-modal"
 import { SellCarSheet } from "@/components/sell-car-sheet"
 import { CheckCircle, Check } from "lucide-react"
@@ -49,6 +50,7 @@ export default function HomeClient({ initialSettings, featuredCars, allCars }: H
 
   const contactButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
   const [showSaleModal, setShowSaleModal] = useState(false)
   const [isSellSheetOpen, setIsSellSheetOpen] = useState(false)
 
@@ -177,8 +179,7 @@ export default function HomeClient({ initialSettings, featuredCars, allCars }: H
       return
     }
 
-    await contactButtonState.execute(async () => {
-      // Сохраняем в Firebase через API
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...contactForm,
@@ -189,8 +190,7 @@ export default function HomeClient({ initialSettings, featuredCars, allCars }: H
       } catch (error) {
       }
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -200,12 +200,11 @@ export default function HomeClient({ initialSettings, featuredCars, allCars }: H
           type: "car_selection",
         }),
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
       setContactForm({ name: "", phone: "+375" })
-      showSuccess(
-        "Ваша заявка успешно отправлена! Мы свяжемся с вами в ближайшее время."
-      )
-    })
+      showSuccess("Ваша заявка успешно отправлена! Мы свяжемся с вами в ближайшее время.")
+    }) // Здесь нет закрывающегося окна, поэтому onCloseCurrentModal не передаем
   }
 
   return (
@@ -425,18 +424,15 @@ export default function HomeClient({ initialSettings, featuredCars, allCars }: H
                   <Check className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-green-400" />
                 )}
               </div>
-              <StatusButton
+              <Button
                 type="submit"
                 size="sm"
                 className="bg-white/20 hover:bg-white/30 dark:bg-gray-700/50 dark:hover:bg-gray-600/60 text-white border border-white/40 dark:border-gray-600 backdrop-blur-sm px-4 h-10 sm:h-9 text-sm whitespace-nowrap"
-                state={contactButtonState.state}
-                loadingText="Отправляем..."
-                successText="Отправлено!"
-                errorText="Ошибка"
+                disabled={!isPhoneValid(contactForm.phone) || !contactForm.name}
               >
                 <CheckCircle className="h-3 w-3 mr-1" />
                 Отправить
-              </StatusButton>
+              </Button>
             </form>
           </div>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { NotificationProvider } from "@/components/providers/notification-provid
 import { ThemeProvider } from "@/components/theme-provider"
 import { CreditLeasingModalProvider } from "@/components/providers/credit-leasing-modal-provider"
 import { CreditLeasingModal } from "@/components/credit-leasing-modal"
+import { SubmissionProvider } from "@/components/providers/submission-provider"
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://belautocenter.by'),
@@ -161,15 +162,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>
           <UsdBynRateProvider>
             <NotificationProvider>
-              <CreditLeasingModalProvider>
-                <Header />
-                <main className="flex-1 flex flex-col">
-                  {children}
-                </main>
-                <Footer />
-                <MobileDock />
-                <CreditLeasingModal />
-              </CreditLeasingModalProvider>
+              <SubmissionProvider>
+                <CreditLeasingModalProvider>
+                  <Header />
+                  <main className="flex-1 flex flex-col">
+                    {children}
+                  </main>
+                  <Footer />
+                  <MobileDock />
+                  <CreditLeasingModal />
+                </CreditLeasingModalProvider>
+              </SubmissionProvider>
             </NotificationProvider>
           </UsdBynRateProvider>
         </ThemeProvider>

--- a/app/leasing/page.tsx
+++ b/app/leasing/page.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label"
 import { Slider } from "@/components/ui/slider"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ChevronRight, Check, DollarSign, Zap, Shield, FileText, Award, Phone, Car, Star, CheckCircle, CreditCard, ChevronDown, ChevronUp, Calculator, Building, TrendingDown, Clock, Users, Target, Briefcase } from "lucide-react"
@@ -49,6 +50,7 @@ export default function LeasingPage() {
   const usdBynRate = useUsdBynRate()
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   const [calculator, setCalculator] = useState({
     carPrice: [50000],
@@ -244,7 +246,7 @@ export default function LeasingPage() {
       return
     }
 
-    await submitButtonState.execute(async () => {
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...leasingForm,
@@ -260,8 +262,7 @@ export default function LeasingPage() {
           ? leasingForm.fullName
           : leasingForm.contactPerson
 
-      // Отправляем уведомление в Telegram (всегда выполняется)
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -280,6 +281,7 @@ export default function LeasingPage() {
           type: "leasing_request",
         }),
       })
+      if (!response.ok) throw new Error("Telegram failed");
 
       setLeasingForm({
         clientType: "organization",
@@ -295,10 +297,8 @@ export default function LeasingPage() {
         company: "",
         message: "",
       })
-      showSuccess(
-        "Заявка на лизинг успешно отправлена! Мы рассмотрим ее и свяжемся с вами в ближайшее время."
-      )
-    })
+      showSuccess("Заявка на лизинг успешно отправлена! Мы рассмотрим ее и свяжемся с вами в ближайшее время.")
+    }) // Здесь нет закрывающегося окна
   }
 
   const monthlyPayment = calculateMonthlyPayment()
@@ -809,17 +809,13 @@ export default function LeasingPage() {
                     </div>
                   </div>
 
-                  <StatusButton
+                  <Button
                     type="submit"
                     className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white rounded-xl py-3 mt-3 font-semibold text-sm shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                    state={submitButtonState.state}
-                    loadingText="Отправляем..."
-                    successText="Отправлено!"
-                    errorText="Ошибка"
                     disabled={!isFormValid()}
                   >
                     Отправить заявку на лизинг
-                  </StatusButton>
+                  </Button>
 
                   <p className="text-xs text-slate-600 dark:text-slate-400 leading-tight text-center">
                     Нажимая кнопку "Отправить заявку на лизинг", вы соглашаетесь с{" "}

--- a/app/sale/page.tsx
+++ b/app/sale/page.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import {
   Car,
   CreditCard,
@@ -202,6 +203,7 @@ export default function SalePage() {
 
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   useEffect(() => {
     setIsVisible(true)
@@ -212,9 +214,7 @@ export default function SalePage() {
   }
 
   const handleSubmit = async () => {
-    try {
-      submitButtonState.setLoading(true)
-
+    await submitForm(async () => {
       const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: {
@@ -229,17 +229,14 @@ export default function SalePage() {
         }),
       })
 
-      if (response.ok) {
-        submitButtonState.setSuccess(true)
-        showSuccess('Заявка отправлена! Мы свяжемся с вами в ближайшее время.')
-        setFormData({ name: '', phone: '+375', message: '' })
-        setSelectedService('')
-      } else {
+      if (!response.ok) {
         throw new Error('Ошибка отправки')
       }
-    } catch (error) {
-      submitButtonState.setError(true)
-    }
+
+      showSuccess('Заявка отправлена! Мы свяжемся с вами в ближайшее время.')
+      setFormData({ name: '', phone: '+375', message: '' })
+      setSelectedService('')
+    }) // Здесь нет окна для закрытия
   }
 
   const canSubmit = formData.name.trim() && formData.phone.length >= 13
@@ -612,15 +609,14 @@ export default function SalePage() {
                       rows={4}
                     />
                   </div>
-                  <StatusButton
-                    {...submitButtonState}
+                  <Button
                     onClick={handleSubmit}
                     disabled={!canSubmit}
                     className="w-full h-14 text-lg rounded-xl bg-gradient-to-r from-emerald-500 to-blue-500 text-white hover:from-emerald-600 hover:to-blue-600 font-bold shadow-lg hover:shadow-xl transition-all"
                   >
                     Отправить заявку
                     <ArrowRight className="ml-2 h-6 w-6" />
-                  </StatusButton>
+                  </Button>
                   <p className="text-center text-xs text-gray-500">
                     Нажимая кнопку, вы соглашаетесь с{' '}
                     <a href="/privacy" className="underline hover:text-blue-600">политикой конфиденциальности</a>

--- a/app/sale/sale-modal.tsx
+++ b/app/sale/sale-modal.tsx
@@ -8,6 +8,7 @@ import { StatusButton } from "@/components/ui/status-button"
 import { X, ChevronLeft, Car, Phone, MessageCircle, Instagram, DollarSign, RotateCcw, TrendingUp, CheckCircle } from "lucide-react"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import { getCachedImageUrl } from "@/lib/image-cache"
 import { isPhoneValid } from "@/lib/validation"
 
@@ -68,6 +69,7 @@ export default function SaleModal({ isOpen, onClose }: SaleModalProps) {
 
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   // Загружаем настройки воронки из Firebase
   useEffect(() => {
@@ -109,9 +111,7 @@ export default function SaleModal({ isOpen, onClose }: SaleModalProps) {
       return
     }
 
-    try {
-      submitButtonState.setLoading(true)
-
+    await submitForm(async () => {
       const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: {
@@ -129,18 +129,12 @@ export default function SaleModal({ isOpen, onClose }: SaleModalProps) {
         }),
       })
 
-      if (response.ok) {
-        submitButtonState.setSuccess(true)
-        showSuccess(funnelSettings.successMessage)
-        setTimeout(() => {
-          onClose()
-        }, 2000)
-      } else {
+      if (!response.ok) {
         throw new Error('Ошибка отправки')
       }
-    } catch (error) {
-      submitButtonState.setError(true)
-    }
+
+      showSuccess(funnelSettings.successMessage)
+    }, onClose)
   }
 
   const canProceedStep1 = formData.carMake.trim() && formData.carModel.trim() && formData.estimatedPrice.trim()
@@ -331,14 +325,13 @@ export default function SaleModal({ isOpen, onClose }: SaleModalProps) {
               {currentStep === 1 ? 'Продолжить' : 'Подтвердить и отправить'}
             </Button>
           ) : (
-            <StatusButton
-              {...submitButtonState}
+            <Button
               onClick={handleSubmit}
               disabled={!canSubmit}
               className="w-full h-12 text-base rounded-lg bg-yellow-400 text-slate-900 hover:bg-yellow-300 font-semibold"
             >
               Отправить заявку
-            </StatusButton>
+            </Button>
           )}
         </div>
       </div>

--- a/components/FinancialAssistantDrawer.tsx
+++ b/components/FinancialAssistantDrawer.tsx
@@ -12,6 +12,7 @@ import { useUsdBynRate } from "@/components/providers/usd-byn-rate-provider"
 import { getCachedImageUrl } from "@/lib/image-cache"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import { parseFirestoreDoc } from "@/lib/firestore-parser"
 import { UniversalDrawer } from "@/components/ui/UniversalDrawer"
 
@@ -47,6 +48,7 @@ export function FinancialAssistantDrawer({ open, onOpenChange, car }: FinancialA
   const usdBynRate = useUsdBynRate();
   const { showSuccess } = useNotification();
   const creditButtonState = useButtonState();
+  const { submitForm } = useSubmission();
 
   // --- COMPONENT STATE ---
   const [partnerBanks, setPartnerBanks] = useState<PartnerBank[]>([]);
@@ -160,7 +162,7 @@ export function FinancialAssistantDrawer({ open, onOpenChange, car }: FinancialA
   const handleCreditSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!car) return;
-    await creditButtonState.execute(async () => {
+    await submitForm(async () => {
       const payload = {
         ...creditForm, carId: car.id, carInfo: `${car.make} ${car.model} ${car.year}`,
         type: financeType, status: "new", createdAt: new Date(),
@@ -172,8 +174,14 @@ export function FinancialAssistantDrawer({ open, onOpenChange, car }: FinancialA
         currency: isBelarusianRubles ? "BYN" : "USD", financeType: financeType,
         creditAmount: creditAmountValue,
       };
-      // Intentionally not awaiting these for faster UI response
-      fetch('/api/send-telegram', {
+
+      try {
+        await firestoreApi.addDocument("leads", payload);
+      } catch(error) {
+        // Ignore firestore errors
+      }
+
+      const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -184,12 +192,11 @@ export function FinancialAssistantDrawer({ open, onOpenChange, car }: FinancialA
           downPayment: formatPrice(financeType === 'credit' ? downPayment[0] : leasingAdvance[0])
         })
       });
-      firestoreApi.addDocument("leads", payload);
+      if (!response.ok) throw new Error("Telegram failed");
 
-      onOpenChange(false);
       setCreditForm({ name: "", phone: "+375", message: "" });
       showSuccess(`Заявка на ${financeType === 'credit' ? 'кредит' : 'лизинг'} успешно отправлена!`);
-    });
+    }, () => onOpenChange(false));
   };
 
   // --- UI RENDER ---
@@ -359,8 +366,8 @@ export function FinancialAssistantDrawer({ open, onOpenChange, car }: FinancialA
 
   const renderFooter = () => (
     <>
-      <Button onClick={handleCreditSubmit} className="w-full h-12 text-base" disabled={!isPhoneValid(creditForm.phone) || !creditForm.name || creditButtonState.isLoading}>
-          {creditButtonState.isLoading ? 'Отправка...' : `Отправить заявку на ${financeType === 'credit' ? 'кредит' : 'лизинг'}`}
+      <Button onClick={handleCreditSubmit} className="w-full h-12 text-base" disabled={!isPhoneValid(creditForm.phone) || !creditForm.name}>
+          {`Отправить заявку на ${financeType === 'credit' ? 'кредит' : 'лизинг'}`}
       </Button>
       <p className="text-xs text-slate-500 dark:text-gray-400 mt-3 text-center">Нажимая кнопку, вы соглашаетесь с <a href="/privacy" className="underline hover:text-blue-600 dark:hover:text-blue-400">политикой обработки персональных данных</a>.</p>
     </>

--- a/components/WarrantyDrawer.tsx
+++ b/components/WarrantyDrawer.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { UniversalDrawer } from "@/components/ui/UniversalDrawer"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 
 interface WarrantyDrawerProps {
   open: boolean;
@@ -16,6 +17,7 @@ interface WarrantyDrawerProps {
 
 export function WarrantyDrawer({ open, onOpenChange, programTitle, programPrice }: WarrantyDrawerProps) {
   const { showSuccess } = useNotification();
+  const { submitForm } = useSubmission();
   const [formData, setFormData] = useState({
     name: "",
     phone: "+375",
@@ -38,8 +40,7 @@ export function WarrantyDrawer({ open, onOpenChange, programTitle, programPrice 
   };
 
   const handleSubmit = async () => {
-    setLoading(true);
-    try {
+    await submitForm(async () => {
       const payload = {
         type: "warranty_request",
         program: programTitle,
@@ -53,7 +54,6 @@ export function WarrantyDrawer({ open, onOpenChange, programTitle, programPrice 
         source: "website_warranty"
       };
 
-      // Send to Telegram (fire and forget for UI speed, but good to await for error handling if critical)
       const response = await fetch('/api/send-telegram', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -65,13 +65,8 @@ export function WarrantyDrawer({ open, onOpenChange, programTitle, programPrice 
       }
 
       showSuccess("Заявка успешно отправлена! Мы свяжемся с вами в ближайшее время.");
-      onOpenChange(false);
       setFormData({ name: "", phone: "+375", car: "", comment: "" });
-    } catch (error) {
-      console.error("Error sending request:", error);
-    } finally {
-      setLoading(false);
-    }
+    }, () => onOpenChange(false));
   };
 
   const footer = (
@@ -79,9 +74,9 @@ export function WarrantyDrawer({ open, onOpenChange, programTitle, programPrice 
       <Button
         onClick={handleSubmit}
         className="w-full h-12 text-base font-semibold rounded-xl"
-        disabled={!isPhoneValid(formData.phone) || !formData.name || loading}
+        disabled={!isPhoneValid(formData.phone) || !formData.name}
       >
-        {loading ? "Отправка..." : "Отправить заявку"}
+        Отправить заявку
       </Button>
       <p className="text-xs text-muted-foreground mt-3 text-center">
         Нажимая кнопку, вы соглашаетесь с <a href="/privacy" className="underline hover:text-primary">политикой обработки персональных данных</a>.

--- a/components/credit-leasing-modal.tsx
+++ b/components/credit-leasing-modal.tsx
@@ -12,6 +12,7 @@ import Link from "next/link"
 import { motion, AnimatePresence } from "framer-motion"
 import Image from "next/image"
 import { getCachedImageUrl } from "@/lib/image-cache"
+import { useSubmission } from "@/components/providers/submission-provider"
 
 interface Car {
   id: string
@@ -49,6 +50,7 @@ export function CreditLeasingModal() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
+  const { submitForm } = useSubmission()
 
   const isPhoneFieldValid = isPhoneValid(phone)
   const isLeasing = type === "leasing"
@@ -113,10 +115,8 @@ export function CreditLeasingModal() {
 
   const handleSubmit = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
-    if (isSubmitting) return;
 
-    setIsSubmitting(true)
-    try {
+    await submitForm(async () => {
       const data = {
         phone,
         car: selectedCar ? `${selectedCar.make} ${selectedCar.model} (${selectedCar.year})` : "Своя сумма",
@@ -125,21 +125,22 @@ export function CreditLeasingModal() {
         createdAt: new Date()
       }
 
-      await firestoreApi.addDocument("leads", data)
+      try {
+        await firestoreApi.addDocument("leads", data)
+      } catch(error) {
+        // Ignore firestore errors
+      }
 
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       })
 
+      if (!response.ok) throw new Error("Telegram failed");
+
       showSuccess(`Заявка на ${isLeasing ? 'лизинг' : 'кредит'} успешно отправлена!`)
-      closeModal()
-    } catch (error) {
-      console.error("Error submitting:", error)
-    } finally {
-      setIsSubmitting(false)
-    }
+    }, closeModal)
   }
 
   const getMonthlyPayment = (car: Car) => {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,6 +17,7 @@ import { BlurImage } from "@/components/ui/blur-image"
 import { Menu, Phone, Loader2, Check, ArrowRight, MapPin, Clock, Moon, Sun } from "lucide-react"
 import { firestoreApi } from "@/lib/firestore-api"
 import { useNotification } from "@/components/providers/notification-provider"
+import { useSubmission } from "@/components/providers/submission-provider"
 import { formatPhoneNumber, isPhoneValid } from "@/lib/validation"
 import { useCreditLeasingModal } from "@/components/providers/credit-leasing-modal-provider"
 
@@ -51,6 +52,7 @@ export default function Header() {
   const [loading, setLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   useEffect(() => {
     loadSettings()
@@ -76,19 +78,19 @@ export default function Header() {
       return
     }
 
-    setIsSubmitting(true)
+    await submitForm(async () => {
+      try {
+        await firestoreApi.addDocument("leads", {
+          ...formData,
+          type: "callback",
+          status: "new",
+          createdAt: new Date(),
+        })
+      } catch (error) {
+        // Ignore firestore errors
+      }
 
-    try {
-      // Сохраняем в Firebase через API
-      await firestoreApi.addDocument("leads", {
-        ...formData,
-        type: "callback",
-        status: "new",
-        createdAt: new Date(),
-      })
-
-      // Отправляем уведомление в Telegram
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -99,16 +101,11 @@ export default function Header() {
         }),
       })
 
-      setIsCallbackOpen(false)
+      if (!response.ok) throw new Error("Telegram failed");
+
       setFormData({ name: "", phone: "+375" })
-      showSuccess(
-        "Заявка на обратный звонок отправлена! Мы свяжемся с вами в ближайшее время."
-      )
-    } catch (error) {
-      showSuccess("Произошла ошибка. Попробуйте еще раз.")
-    } finally {
-      setIsSubmitting(false)
-    }
+      showSuccess("Заявка на обратный звонок отправлена! Мы свяжемся с вами в ближайшее время.")
+    }, () => setIsCallbackOpen(false))
   }
 
   return (

--- a/components/providers/submission-provider.tsx
+++ b/components/providers/submission-provider.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+export type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface SubmissionContextType {
+  submitForm: (
+    action: () => Promise<void>,
+    onCloseCurrentModal?: () => void
+  ) => Promise<void>
+}
+
+const SubmissionContext = createContext<SubmissionContextType | undefined>(undefined)
+
+export function SubmissionProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [status, setStatus] = useState<SubmissionStatus>('idle')
+
+  const submitForm = async (action: () => Promise<void>, onCloseCurrentModal?: () => void) => {
+    // Если уже идет отправка, игнорируем
+    if (isOpen) return
+
+    setIsOpen(true)
+    setStatus('loading')
+
+    // Закрываем предыдущее окно сразу
+    if (onCloseCurrentModal) {
+      onCloseCurrentModal()
+    }
+
+    try {
+      // Запускаем действие и таймер минимум 1.8 секунд параллельно
+      await Promise.all([
+        action(),
+        new Promise(resolve => setTimeout(resolve, 1800))
+      ])
+
+      setStatus('success')
+
+      // Ждем 2 секунды перед закрытием модалки успеха
+      await new Promise(resolve => setTimeout(resolve, 2000))
+    } catch (error) {
+      console.error("Submission error:", error)
+      setStatus('error')
+
+      // Ждем 2 секунды перед закрытием модалки ошибки
+      await new Promise(resolve => setTimeout(resolve, 2000))
+    } finally {
+      setIsOpen(false)
+      setTimeout(() => setStatus('idle'), 300) // Даем время на анимацию скрытия
+    }
+  }
+
+  return (
+    <SubmissionContext.Provider value={{ submitForm }}>
+      {children}
+      <SubmissionModal isOpen={isOpen} status={status} />
+    </SubmissionContext.Provider>
+  )
+}
+
+export const useSubmission = () => {
+  const context = useContext(SubmissionContext)
+  if (context === undefined) {
+    throw new Error('useSubmission must be used within a SubmissionProvider')
+  }
+  return context
+}
+
+// Meta-style Submission Modal
+function SubmissionModal({ isOpen, status }: { isOpen: boolean, status: SubmissionStatus }) {
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40 backdrop-blur-sm"
+        >
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+            className="w-32 h-32 bg-white dark:bg-[#1c1e21] rounded-2xl shadow-[0_4px_12px_rgba(0,0,0,0.15)] flex flex-col items-center justify-center relative overflow-hidden"
+          >
+            {status === 'loading' && (
+              <svg className="w-10 h-10 animate-spin text-[#0064e0] dark:text-[#2374e1]" viewBox="0 0 50 50">
+                <circle
+                  cx="25"
+                  cy="25"
+                  r="20"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                  strokeDasharray="90 150"
+                  className="opacity-20"
+                />
+                <circle
+                  cx="25"
+                  cy="25"
+                  r="20"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                  strokeDasharray="90 150"
+                  strokeDashoffset="0"
+                >
+                  <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 25 25"
+                    to="360 25 25"
+                    dur="1.5s"
+                    repeatCount="indefinite"
+                  />
+                </circle>
+              </svg>
+            )}
+
+            {status === 'success' && (
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                className="w-12 h-12 bg-[#00a400] rounded-full flex items-center justify-center"
+              >
+                <svg className="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <motion.path
+                    initial={{ pathLength: 0 }}
+                    animate={{ pathLength: 1 }}
+                    transition={{ duration: 0.4, ease: "easeOut", delay: 0.2 }}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              </motion.div>
+            )}
+
+            {status === 'error' && (
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                className="w-12 h-12 bg-[#fa383e] rounded-full flex items-center justify-center"
+              >
+                <svg className="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <motion.path
+                    initial={{ pathLength: 0 }}
+                    animate={{ pathLength: 1 }}
+                    transition={{ duration: 0.4, ease: "easeOut", delay: 0.2 }}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </motion.div>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/sell-car-sheet.tsx
+++ b/components/sell-car-sheet.tsx
@@ -8,6 +8,7 @@ import { UniversalDrawer } from "@/components/ui/UniversalDrawer"
 import { useButtonState } from "@/hooks/use-button-state"
 import { useNotification } from "@/components/providers/notification-provider"
 import { StatusButton } from "@/components/ui/status-button"
+import { useSubmission } from "@/components/providers/submission-provider"
 import {
   DollarSign,
   Zap,
@@ -48,6 +49,7 @@ export function SellCarSheet({ open, onOpenChange }: SellCarSheetProps) {
 
   const submitButtonState = useButtonState()
   const { showSuccess } = useNotification()
+  const { submitForm } = useSubmission()
 
   useEffect(() => {
     if (open) {
@@ -73,7 +75,7 @@ export function SellCarSheet({ open, onOpenChange }: SellCarSheetProps) {
       return
     }
 
-    await submitButtonState.execute(async () => {
+    await submitForm(async () => {
       try {
         await firestoreApi.addDocument("leads", {
           ...formData,
@@ -85,7 +87,7 @@ export function SellCarSheet({ open, onOpenChange }: SellCarSheetProps) {
         // Ignore firestore error
       }
 
-      await fetch("/api/send-telegram", {
+      const response = await fetch("/api/send-telegram", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -97,10 +99,11 @@ export function SellCarSheet({ open, onOpenChange }: SellCarSheetProps) {
         }),
       })
 
+      if (!response.ok) throw new Error("Failed to send to telegram");
+
       setFormData({ name: "", phone: "+375" })
       showSuccess("Заявка принята! Мы свяжемся с вами для обсуждения продажи вашего авто.")
-      setTimeout(() => onOpenChange(false), 2000)
-    })
+    }, () => onOpenChange(false))
   }
 
   const advantages = [


### PR DESCRIPTION
This submission introduces a unified `SubmissionProvider` to handle all Telegram form submissions consistently across the site. It fulfills the user's requirements by:

1. Blocking multiple submissions by turning the submit button into a standard `Button` with a `disabled` state when appropriate, and letting the `useSubmission` hook handle the "loading" blockage via its internal state.
2. Displaying a square modal window with a custom meta-style loader, which spins for a minimum of 1.8 seconds.
3. Automatically closing the previously active dialog or drawer right away while the submission modal stays visible, completing the flow gracefully.
4. Showing a green checkmark or red cross in the modal after the loader finishes, based on the submission outcome.

The old `StatusButton` instances were replaced with standard `Button` components as the loading state is now visually handled by the global modal.

---
*PR created automatically by Jules for task [12444175016984848315](https://jules.google.com/task/12444175016984848315) started by @tuttoxa9*