### PR TITLE
feat: Add warranty badge to car cards and details page

### DIFF
--- a/app/catalog/[id]/car-details-client.tsx
+++ b/app/catalog/[id]/car-details-client.tsx
@@ -44,7 +44,8 @@ import {
   Calendar,
   Clock,
   AlertCircle,
-  Check
+  Check,
+  ShieldCheck
 } from "lucide-react"
 import { Checkbox } from "@/components/ui/checkbox"
 import CarPrice from "@/components/car-price"
@@ -786,7 +787,7 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
                       {car?.make} {car?.model}
                     </h1>
                   )}
-                  <div className="self-start sm:self-auto">
+                  <div className="flex flex-wrap items-center gap-1.5 xs:gap-2 self-start sm:self-auto">
                     {loading ? (
                       <div className="h-5 xs:h-6 sm:h-7 bg-slate-300 dark:bg-gray-700 rounded-full w-12 xs:w-16 animate-pulse"></div>
                     ) : car?.isAvailable ? (
@@ -796,6 +797,14 @@ export default function CarDetailsClient({ carId, initialCar }: CarDetailsClient
                     ) : (
                       <div className="bg-red-500 dark:bg-red-600 text-white px-1.5 xs:px-2 sm:px-3 py-0.5 xs:py-1 rounded-full text-[10px] xs:text-xs sm:text-sm font-bold inline-block">
                         Продан
+                      </div>
+                    )}
+
+                    {/* Бейдж Гарантия */}
+                    {!loading && (
+                      <div className="flex items-center gap-1 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800 px-1.5 xs:px-2 sm:px-3 py-0.5 xs:py-1 rounded-full text-[10px] xs:text-xs sm:text-sm font-bold">
+                        <ShieldCheck className="h-3 w-3 xs:h-3.5 xs:w-3.5 sm:h-4 sm:w-4" />
+                        <span>Гарантия</span>
                       </div>
                     )}
                   </div>

--- a/components/car-card.tsx
+++ b/components/car-card.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-
+import { ShieldCheck } from "lucide-react"
 
 import { useState, useEffect, useMemo } from "react"
 import { getCachedImageUrl } from "@/lib/image-cache"
@@ -96,8 +96,20 @@ export default function CarCard({ car, disableImageBlur }: CarCardProps) {
 
 
 
+            {/* Гарантия */}
+            <div className="absolute top-2 left-2 sm:top-3 sm:left-3 z-10">
+              {!dataReady ? (
+                <div className="h-5 w-16 sm:h-6 sm:w-20 bg-slate-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+              ) : (
+                <div className="flex items-center gap-1 bg-green-500/90 backdrop-blur-sm text-white px-1.5 py-0.5 sm:px-2 sm:py-1 rounded-md shadow-sm">
+                  <ShieldCheck className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                  <span className="text-[9px] sm:text-[10px] font-bold uppercase tracking-wider">Гарантия</span>
+                </div>
+              )}
+            </div>
+
             {/* Year - скелетон или данные */}
-            <div className="absolute top-2 right-2 sm:top-3 sm:right-3">
+            <div className="absolute top-2 right-2 sm:top-3 sm:right-3 z-10">
               {!dataReady ? (
                 <div className="h-5 w-10 sm:h-6 sm:w-12 bg-slate-200 dark:bg-zinc-800 rounded animate-pulse"></div>
               ) : (


### PR DESCRIPTION
- Added a compact `ShieldCheck` icon from `lucide-react` to `components/car-card.tsx` as an overlay on the image.
- Added a similar badge to `app/catalog/[id]/car-details-client.tsx` next to the availability status.
- Styled badges using Tailwind CSS with green semi-transparent background and blur effect to match user preferences.
- Cleaned up development artifacts before committing.